### PR TITLE
Documented and cleaned up `ozip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## [1.0.0] - 2023-02-XX
+
+### New Features
+- Function ``ozip`` to group adjacent elements of a list into groups of a given size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [1.0.1] - 2023-XX-XX
+- Cleaned up and documented the ``ozip`` function.
+
 ## [1.0.0] - 2023-02-XX
 
 ### New Features

--- a/src/osgood/base.py
+++ b/src/osgood/base.py
@@ -6,8 +6,8 @@ from typing import Any
 def ozip(list_to_zip: list[Any], groups: int) -> list[tuple]:
     """Zips adjacent elements of list ``list_to_zip`` into groupings of a given size.
 
-    If len(list_to_zip) % groups != 0, the remaining elements are ommitted.
-    If groups is larger than len(list_to_zip), then an empty list is returned.
+    If ``len(list_to_zip) % groups != 0``, the remaining elements are ommitted.
+    If ``groups > len(list_to_zip)``, then an empty list is returned.
 
     Parameters
     ----------

--- a/src/osgood/base.py
+++ b/src/osgood/base.py
@@ -1,22 +1,31 @@
 # A collection of useful functions
 import warnings
-from typing import List, Tuple
+from typing import Any
 
 
-def ozip(list_to_zip: list, groups: int) -> List[Tuple]:
-    """Zips passed list [list_to_zip] into number of groups passed as a param
+def ozip(list_to_zip: list[Any], groups: int) -> list[tuple]:
+    """Zips adjacent elements of list ``list_to_zip`` into groupings of a given size.
+
     If len(list_to_zip) % groups != 0, the remaining elements are ommitted.
-    If groups is larger than len(list_to_zip), then an empty list is returned."""
-    if groups > len(list_to_zip):
-        warnings.warn(
-            "Groups larger than length of list passed, empty list will be returned"
-        )
-        return list(zip(*[iter(list_to_zip)] * groups))
+    If groups is larger than len(list_to_zip), then an empty list is returned.
+
+    Parameters
+    ----------
+    list_to_zip
+        The input list whose elements to group-wise zip.
+    group
+        The size of each group in the resulting zip.
+
+    Returns
+    -------
+    list[tuple]
+        The resulting list of groupings as tuples.
+    """
     if len(list_to_zip) % groups != 0:
         remainder = len(list_to_zip) % groups
         warnings.warn(
-            f"This part of passed list will be shaved off: {str(list_to_zip[len(list_to_zip)-remainder:])}"
+            f"This part of passed list will be shaved off: {list_to_zip[-1 * remainder:]}"
         )
-        return list(zip(*[iter(list_to_zip)] * groups))
-    else:
-        list(zip(*[iter(list_to_zip)] * groups))
+
+    return list(zip(*[iter(list_to_zip)] * groups))
+


### PR DESCRIPTION
I removed a lot of the repetition of the osgoodian zip code happening. Also the case where `groups > len(list)` is actually a subset of the case `len(list) % groups != 0`. So I removed the warning of the empty list. The warning of the modulo will show all of the elements being trimmed off.

Also, the trimming could be simplified by negative indexing.

I documented the function using `numpy` styling. This is a common Python function documentation format where you list all of the parameters and what they are in detail as well as explain the return vale of the function.

Also, I incremented the CHANGELOG version according to https://docs.npmjs.com/about-semantic-versioning/ . This is called `Semantic Versioning` and a widely used standard for picking version numbers.