### PR TITLE
Implement `None` padding in  `ozip` of straggling elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
-## [1.0.1] - 2023-XX-XX
+## [1.1.0] - 2023-XX-XX
+
+### New Features
+- Implemented ``pad`` parameter to group any straggling elements with ``None``.
+
+### Other Changes
 - Cleaned up and documented the ``ozip`` function.
 
 ## [1.0.0] - 2023-02-XX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## [1.0.0] - 2023-02-XX
+
+### New Features
+- Function ``ozip`` to group adjacent elements of a list into groups of a given size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [1.0.1] - 2023-XX-XX
+- Cleaned up and documented the ``ozip`` function.
+
 ## [1.0.0] - 2023-02-XX
 
 ### New Features

--- a/src/osgood/base.py
+++ b/src/osgood/base.py
@@ -1,13 +1,11 @@
 # A collection of useful functions
 import warnings
+from itertools import repeat, chain
 from typing import Any
 
 
-def ozip(list_to_zip: list[Any], groups: int) -> list[tuple]:
+def ozip(list_to_zip: list[Any], groups: int, pad: bool = False) -> list[tuple]:
     """Zips adjacent elements of list ``list_to_zip`` into groupings of a given size.
-
-    If ``len(list_to_zip) % groups != 0``, the remaining elements are ommitted.
-    If ``groups > len(list_to_zip)``, then an empty list is returned.
 
     Parameters
     ----------
@@ -15,17 +13,26 @@ def ozip(list_to_zip: list[Any], groups: int) -> list[tuple]:
         The input list whose elements to group-wise zip.
     group
         The size of each group in the resulting zip.
+    pad
+        A flag whether to pad with ``None`` any ungrouped straggling 
+        elements of ``list_to_zip`` to form one final group. When left
+        as `False`, then if ``len(list_to_zip) % groups != 0``, 
+        the remaining elements are ommitted.
 
     Returns
     -------
     list[tuple]
         The resulting list of groupings as tuples.
     """
-    if len(list_to_zip) % groups != 0:
-        remainder = len(list_to_zip) % groups
+    pad_len = groups - len(list_to_zip) % groups
+    
+    if not pad and pad_len != 0:
+        n_trim = groups - pad_len
         warnings.warn(
-            f"This part of passed list will be shaved off: {list_to_zip[-1 * remainder:]}"
+            f"This part of passed list will be shaved off: {list_to_zip[-1 * n_trim:]}"
         )
-
-    return list(zip(*[iter(list_to_zip)] * groups))
+    
+    # Pad with `None` if requested
+    iterator = chain(list_to_zip, repeat(None, pad_len if pad else 0))
+    return list(zip(*[iter(iterator)] * groups))
 

--- a/src/osgood/base.py
+++ b/src/osgood/base.py
@@ -6,8 +6,8 @@ from typing import Any
 def ozip(list_to_zip: list[Any], groups: int) -> list[tuple]:
     """Zips adjacent elements of list ``list_to_zip`` into groupings of a given size.
 
-    If len(list_to_zip) % groups != 0, the remaining elements are ommitted.
-    If groups is larger than len(list_to_zip), then an empty list is returned.
+    If ``len(list_to_zip) % groups != 0``, the remaining elements are ommitted.
+    If ``groups > len(list_to_zip)``, then an empty list is returned.
 
     Parameters
     ----------

--- a/src/osgood/base.py
+++ b/src/osgood/base.py
@@ -1,22 +1,31 @@
 # A collection of useful functions
 import warnings
-from typing import List, Tuple
+from typing import Any
 
 
-def ozip(list_to_zip: list, groups: int) -> List[Tuple]:
-    """Zips passed list [list_to_zip] into number of groups passed as a param
+def ozip(list_to_zip: list[Any], groups: int) -> list[tuple]:
+    """Zips adjacent elements of list ``list_to_zip`` into groupings of a given size.
+
     If len(list_to_zip) % groups != 0, the remaining elements are ommitted.
-    If groups is larger than len(list_to_zip), then an empty list is returned."""
-    if groups > len(list_to_zip):
-        warnings.warn(
-            "Groups larger than length of list passed, empty list will be returned"
-        )
-        return list(zip(*[iter(list_to_zip)] * groups))
+    If groups is larger than len(list_to_zip), then an empty list is returned.
+
+    Parameters
+    ----------
+    list_to_zip
+        The input list whose elements to group-wise zip.
+    group
+        The size of each group in the resulting zip.
+
+    Returns
+    -------
+    list[tuple]
+        The resulting list of groupings as tuples.
+    """
     if len(list_to_zip) % groups != 0:
         remainder = len(list_to_zip) % groups
         warnings.warn(
-            f"This part of passed list will be shaved off: {str(list_to_zip[len(list_to_zip)-remainder:])}"
+            f"This part of passed list will be shaved off: {list_to_zip[-1 * remainder:]}"
         )
-        return list(zip(*[iter(list_to_zip)] * groups))
-    else:
-        list(zip(*[iter(list_to_zip)] * groups))
+
+    return list(zip(*[iter(list_to_zip)] * groups))
+

--- a/src/osgood/base.py
+++ b/src/osgood/base.py
@@ -14,9 +14,9 @@ def ozip(list_to_zip: list[Any], groups: int, pad: bool = False) -> list[tuple]:
     group
         The size of each group in the resulting zip.
     pad
-        A flag whether to pad with ``None`` any ungrouped straggling 
+        A flag whether to pad with ``None`` any ungrouped straggling
         elements of ``list_to_zip`` to form one final group. When left
-        as `False`, then if ``len(list_to_zip) % groups != 0``, 
+        as `False`, then if ``len(list_to_zip) % groups != 0``,
         the remaining elements are ommitted.
 
     Returns
@@ -25,14 +25,13 @@ def ozip(list_to_zip: list[Any], groups: int, pad: bool = False) -> list[tuple]:
         The resulting list of groupings as tuples.
     """
     pad_len = groups - len(list_to_zip) % groups
-    
+
     if not pad and pad_len != 0:
         n_trim = groups - pad_len
         warnings.warn(
             f"This part of passed list will be shaved off: {list_to_zip[-1 * n_trim:]}"
         )
-    
+
     # Pad with `None` if requested
     iterator = chain(list_to_zip, repeat(None, pad_len if pad else 0))
     return list(zip(*[iterator] * groups))
-

--- a/src/osgood/base.py
+++ b/src/osgood/base.py
@@ -34,5 +34,5 @@ def ozip(list_to_zip: list[Any], groups: int, pad: bool = False) -> list[tuple]:
     
     # Pad with `None` if requested
     iterator = chain(list_to_zip, repeat(None, pad_len if pad else 0))
-    return list(zip(*[iter(iterator)] * groups))
+    return list(zip(*[iterator] * groups))
 


### PR DESCRIPTION
Any elements that are not able to be grouped may be grouped with the value `None` if the parameter `pad=True`.