### PR TITLE
Implement `timeit` decorator

### DIFF
--- a/src/osgood/base.py
+++ b/src/osgood/base.py
@@ -1,6 +1,27 @@
 # A collection of useful functions
 import warnings
-from typing import List, Tuple
+import time
+from functools import wraps
+from typing import List, Tuple, Optional, Callable
+
+
+def timeit(fn_identifier: Optional[str] = None) -> Callable:
+    def decorator(func: Callable):
+        # Default to the name of the function if no identifier is supplied
+        fn_identifier = func.__name__ if fn_identifier is None else fn_identifier
+
+        @wraps(func)
+        def inner(*args: Any, **kwargs: Any) -> Any:
+            start = time.perf_counter()
+            result = func(*args, **kwargs)
+            end = time.perf_counter()
+
+            print(f"Elapsed time ({fn_identifier}): {end - start}")
+            return result
+
+        return inner
+
+    return decorator
 
 
 def ozip(list_to_zip: list, groups: int) -> List[Tuple]:

--- a/src/osgood/base.py
+++ b/src/osgood/base.py
@@ -6,6 +6,21 @@ from typing import List, Tuple, Optional, Callable
 
 
 def timeit(fn_identifier: Optional[str] = None) -> Callable:
+    """Decorates a function such that its execution time is printed.
+
+    Parameters
+    ----------
+    fn_identifier
+        An optional string to print along with the execution time to make
+        the association simpler between function and time. Defaults to
+        the name of the decorated function.
+
+    Returns
+    -------
+    Callable
+        The decorated function that will track the execution time.
+    """
+
     def decorator(func: Callable):
         # Default to the name of the function if no identifier is supplied
         fn_identifier = func.__name__ if fn_identifier is None else fn_identifier


### PR DESCRIPTION
This pull request introduces a useful `timeit` decorator which is used to time the execution of a decorated function. Useful for ad hoc code profiling.

Required:
- [ ] Add relevant CHANGELOG entry
- [ ] Test the code